### PR TITLE
Fixed the behavior that the default value is always inserted

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/go-playground/locales/ja_JP"
-	"github.com/go-playground/universal-translator"
+	ut "github.com/go-playground/universal-translator"
 	"github.com/labstack/echo"
 	_ "github.com/lib/pq"
 	"gopkg.in/go-playground/validator.v9"
@@ -52,7 +52,7 @@ type Error struct {
 // Comment is a struct to hold unit of request and response.
 type Comment struct {
 	Id      int64     `json:"id" db:"id,primarykey,autoincrement"`
-	Name    string    `json:"name" form:"name" db:"name,notnull,default:'名無し',size:200"`
+	Name    string    `json:"name" form:"name" db:"name,notnull,size:200"`
 	Text    string    `json:"text" form:"text" validate:"required,max=20" db:"text,notnull,size:399"`
 	Created time.Time `json:"created" db:"created,notnull"`
 	Updated time.Time `json:"updated" db:"updated,notnull"`
@@ -60,6 +60,9 @@ type Comment struct {
 
 // PreInsert update fields Created and Updated.
 func (c *Comment) PreInsert(s gorp.SqlExecutor) error {
+	if c.Name == "" {
+		c.Name = "名無し"
+	}
 	c.Created = time.Now()
 	c.Updated = c.Created
 	return nil


### PR DESCRIPTION
Hi!

First of all, thank you so much for this very nice sample.

# Issue

![echo-example](https://user-images.githubusercontent.com/12206485/68085805-35046a80-fe88-11e9-85f2-81ce68fdd61f.gif)

Even if a name is specified, the default value of the tag is always inserted.

# Environment

My operating environment is as follows.

* OS: macOS Catalina 10.15.1
* Go: Ver. 1.13.4
* gorp: [03c0a1b](https://github.com/go-gorp/gorp/commit/03c0a1b1694b62e7517bd2282d485bae5d9cd314)
* DB: PostgreSQL Ver. 12.0-2 on docker
